### PR TITLE
Change Velodyne to MID360

### DIFF
--- a/igvc/launch/mid360_segmentation.launch
+++ b/igvc/launch/mid360_segmentation.launch
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+
+<launch>
+    <!-- Ground segmentation -->
+    <node name="ground_segmentation" pkg="linefit_ground_segmentation_ros" type="ground_segmentation_node">
+        <rosparam command="load" file="$(find igvc)/params/segmentation_params.yaml"/>
+        <param name="input_topic"           value="/livox/points"/>
+        <param name="ground_output_topic"   value="/ground_cloud"/>
+        <param name="obstacle_output_topic" value="obstacle_cloud"/>
+    </node>
+
+    <!-- Convert 3d pointcloud to 2d laserscan -->
+    <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="pointcloud_to_laserscan">
+        <remap from="cloud_in" to="ground_segmentation/obstacle_cloud"/>
+        <!-- <remap from="cloud_in" to="velodyne_points"/> -->
+        <remap from="scan"     to="velodyne_scan"/>
+        <rosparam command="load" file="$(find igvc)/params/pointcloud_to_laserscan_params.yaml"/>
+    </node>
+    
+    <!-- Merge hokuyo_scan & scan from velodyne pointcloud
+    <node pkg="ira_laser_tools" name="laserscan_multi_merger" type="laserscan_multi_merger" output="screen">
+      <param name="destination_frame" value="velodyne_link"/>
+      <param name="scan_destination_topic" value="/scan"/>
+      <param name="cloud_destination_topic" value="/merged_cloud"/>
+      <param name="laserscan_topics" value ="/velodyne_scan /hokuyo_scan" /> --><!-- LIST OF THE LASER SCAN TOPICS TO SUBSCRIBE -->
+     <!-- <param name="angle_min" value="-2.6178"/>
+      <param name="angle_max" value="2.6178"/>
+      <param name="angle_increment" value="0.008711645"/>
+      <param name="scan_time" value="0.0333333"/>
+      <param name="range_min" value="0.30"/>
+      <param name="range_max" value="100.0"/>
+    </node> -->
+</launch>

--- a/igvc/launch/mid360_sensors.launch
+++ b/igvc/launch/mid360_sensors.launch
@@ -56,7 +56,7 @@
     
     <node name="combine_dr_measurements" pkg="robot_pose_ekf" type="robot_pose_ekf">
         <remap from="odom"         to="/odom"/>
-        <remap from="imu_data"     to="/imu"/>
+        <remap from="imu_data"     to="/livox/imu"/>
         <param name="freq"                 value="30.0"/>
         <param name="sensor_timeout"       value="1.0"/>
         <param name="publish_tf"           value="true"/>

--- a/igvc/launch/mid360_sensors.launch
+++ b/igvc/launch/mid360_sensors.launch
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<launch>
+    <!-- Arguments -->
+    <arg name="model"            default="$(find xacro)/xacro '$(find igvc)/urdf/orange.xacro'" />
+    <arg name="LED_dev"          default="/dev/sensors/LED"/>
+    <arg name="gps_dev"          default="/dev/sensors/CLAS"/>
+    <arg name="gps1_dev"         default="/dev/sensors/GNSSbase"/>
+    <arg name="gps2_dev"         default="/dev/sensors/GNSSrover"/>
+    <arg name="use_ekf"          default="true"/>
+    
+    <!-- Run a python script to the send a service call to gazebo_ros to spawn a URDF robot -->
+    <param name="robot_description" command="$(arg model)"/>
+    
+    <!-- Convert joint states to TF transforms for rviz, etc -->
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="false" output="screen"/>
+    
+    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+        <param name="use_gui" value="true"/>
+        <param name="rate"    value="50"/>
+    </node>
+    
+    <!-- Node to setting up Arduino serial communication for LEDs -->
+    <node pkg="rosserial_python" type="serial_node.py" name="serial_node_LED">
+        <param name="port" value="$(arg LED_dev)"/>
+        <param name="baud" value="115200"/>
+    </node>
+    
+    <!-- Use Mid360 -->
+    <include file="$(find livox_ros_driver2)/launch/msg_MID360.launch"/>
+    
+    <!-- Convert message /livox/lidar to /livox/points -->
+    <node pkg="livox_to_pointcloud2" type="livox_to_pointcloud2_node" name="livox_to_pointcloud2">
+       
+    <!-- Ground segmentation, Pointcloud to laserscan, Merge scans -->
+    <include file="$(find igvc)/launch/mid360_segmentation.launch"/>
+    
+    <!-- Sensor fusion 
+    <node pkg="robot_localization" type="ekf_localization_node" name="ekf_localization" clear_params="true" output="screen">
+        <rosparam command="load" file="$(find igvc)/config/ekf.yaml" />
+        <remap from="odom0" to="/odom" />
+        <remap from="odom1" to="/odometry/gps" />
+        <remap from="imu0" to="/imu" />
+    </node>
+    
+    <node pkg="robot_localization" type="navsat_transform_node" name="navsat_transform" clear_params="true" output="screen">
+        <rosparam command="load" file="$(find igvc)/config/navsatekf.yaml" />
+        <remap from="/imu/data" to="/imu" />
+        <remap from="/gps/fix" to="/fix" />
+    </node>
+    
+    <node pkg="nmea_navsat_driver" type="nmea_serial_driver" name="navsat" respawn="true">
+        <param name="port" value="$(arg gps_dev)"/>
+        <param name="baud" value="19200"/>
+    </node>
+    -->
+    
+    <node name="combine_dr_measurements" pkg="robot_pose_ekf" type="robot_pose_ekf">
+        <remap from="odom"         to="/odom"/>
+        <remap from="imu_data"     to="/imu"/>
+        <param name="freq"                 value="30.0"/>
+        <param name="sensor_timeout"       value="1.0"/>
+        <param name="publish_tf"           value="true"/>
+        <param name="odom_used"            value="true"/>
+        <param name="imu_used"             value="true"/>
+        <param name="vo_used"              value="false"/>
+        <param name="output_frame"         value="odom"/>
+        <param name="base_footprint_frame" value="base_footprint"/>
+    </node>
+    
+</launch>

--- a/igvc/urdf/orange2024.xacro
+++ b/igvc/urdf/orange2024.xacro
@@ -23,13 +23,13 @@
   <!-- Import 3D LiDAR model -->
   <xacro:include filename="$(find igvc)/urdf/sensors/livox.urdf.xacro"/>
   <xacro:sensor_velodyne name="livox" parent="base_link" min_angle="-2.35619" max_angle="2.35619" samples="720">
-    <origin xyz="-0.13 0.0 0.70" rpy="0.0 ${PI} 0.0"/>
+    <origin xyz="-0.13 0.0 0.70" rpy="${PI} 0.0 0.0"/>
   </xacro:sensor_velodyne>
   
   <!-- Import imu model -->
   <xacro:include filename="$(find igvc)/urdf/sensors/imu.urdf.xacro"/>
   <xacro:sensor_imu name="imu" parent="base_link" size="0.05 0.05 0.05">
-    <origin xyz="0 0.0 0.068" rpy="0.0 0.0 0.0"/>
+    <origin xyz="-0.13 0.0 0.7" rpy="0.0 ${PI} 0.0"/>
   </xacro:sensor_imu>
   
   <!-- Import gps model -->

--- a/igvc/urdf/orange2024.xacro
+++ b/igvc/urdf/orange2024.xacro
@@ -1,0 +1,179 @@
+<?xml version="1.0"?>
+<!-- Revolute-Revolute Manipulator -->
+<robot name="orange" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <!-- Constants for robot dimensions -->
+  <xacro:property name="PI" value="3.1415926535897931"/>
+  
+  <!-- Macro -->
+  <xacro:macro name="box_inertia" params="m x y z">
+    <inertia ixx="${m*(y*y+z*z)/12.0}" ixy = "0.0" ixz = "0.0"
+             iyy="${m*(z*z+x*x)/12.0}" iyz = "0.0"
+             izz="${m*(x*x+y*y)/12.0}" />
+  </xacro:macro>
+  <xacro:macro name="cylinder_inertia" params="m r h">
+    <inertia ixx="${m*(3*r*r+h*h)/12.0}" ixy = "0.0" ixz = "0.0"
+             iyy="${m*(3*r*r+h*h)/12.0}" iyz = "0.0"
+             izz="${m*r*r/2.0}" />
+  </xacro:macro>
+
+  <!-- Import gazebo reference -->
+  <xacro:include filename="$(find igvc)/urdf/orange.gazebo"/>
+    
+  <!-- Import 3D LiDAR model -->
+  <xacro:include filename="$(find igvc)/urdf/sensors/livox.urdf.xacro"/>
+  <xacro:sensor_velodyne name="livox" parent="base_link" min_angle="-2.35619" max_angle="2.35619" samples="720">
+    <origin xyz="-0.13 0.0 0.70" rpy="0.0 ${PI} 0.0"/>
+  </xacro:sensor_velodyne>
+  
+  <!-- Import imu model -->
+  <xacro:include filename="$(find igvc)/urdf/sensors/imu.urdf.xacro"/>
+  <xacro:sensor_imu name="imu" parent="base_link" size="0.05 0.05 0.05">
+    <origin xyz="0 0.0 0.068" rpy="0.0 0.0 0.0"/>
+  </xacro:sensor_imu>
+  
+  <!-- Import gps model -->
+  <xacro:include filename="$(find igvc)/urdf/sensors/gps.urdf.xacro"/>
+  <xacro:sensor_gps name="gps" parent="base_link">
+    <origin xyz="0.5 0 0.75" rpy="0 ${PI} 0"/>
+  </xacro:sensor_gps>
+  
+  <!-- Base Footprint -->
+  <joint name="base_joint" type="fixed">
+    <parent link="base_footprint"/>
+    <child link="base_link"/>
+    <origin xyz="0.0 0.0 0.1015" rpy="0 0 0"/>
+  </joint>
+  
+  <link name="base_footprint"/>
+  
+  <!-- Base Link -->
+  <link name="base_link">
+    <collision>
+      <origin xyz="-0.33 0.0 0.25" rpy="0.0 0.0 0.0"/>
+      <geometry>
+        <box size="0.9 0.5 0.5"/>
+      </geometry>
+    </collision>
+
+    <visual>
+      <origin xyz="-0.355 0.0 0.3" rpy="0.0 0.0 0.0"/>
+      <geometry>
+        <mesh filename="package://igvc/meshes/IGVCchassis.dae"/>
+      </geometry>
+    </visual>
+
+    <inertial>
+       <mass value="40" />
+       <origin xyz="-0.33 0.0 0.26" rpy="0.0 0.0 0.0"/>
+       <xacro:box_inertia m="40" x="0.9" y="0.5" z="0.45"/>
+    </inertial>
+  </link>
+  
+  <!-- Back wheels -->
+  <joint name="left_caster_hinge" type ="fixed">
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+    <child link="left_caster_link"/>
+    <parent link="base_link"/>
+  </joint>
+  
+  <joint name="right_caster_hinge" type ="fixed">
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+    <child link="right_caster_link"/>
+    <parent link="base_link"/>
+  </joint>
+  
+  <link name="left_caster_link">
+    <collision>
+      <origin xyz="-0.735 0.10 -0.039" rpy="0.0 ${PI/2} ${PI/2}"/>
+      <geometry>
+        <sphere radius="0.0625"/>
+      </geometry>
+    </collision>
+    
+    <visual>
+      <origin xyz="-0.735 0.10 -0.039" rpy="0.0 0.0 0.0"/>
+      <geometry>
+        <mesh filename="package://igvc/meshes/left_back_wheel.dae"/>
+      </geometry>
+    </visual>
+  </link>
+  
+  <link name="right_caster_link">
+    <collision>
+      <origin xyz="-0.735 -0.10 -0.039" rpy="0.0 ${PI/2} ${PI/2}"/>
+      <geometry>
+        <sphere radius="0.0625"/>
+      </geometry>
+    </collision>
+    
+    <visual>
+      <origin xyz="-0.735 -0.10 -0.039" rpy="0.0 0.0 0.0"/>
+      <geometry>
+        <mesh filename="package://igvc/meshes/right_back_wheel.dae"/>
+        <sphere radius="0.0625"/>
+      </geometry>
+    </visual>
+  </link>
+  
+  <!-- Front wheels -->
+  <joint type="revolute" name="left_wheel_hinge">
+    <origin xyz="0.0 0.28 0.0" rpy="0.0 0.0 0.0"/>
+    <child link="left_wheel">left_wheel</child>
+    <parent link="base_link">base_link</parent>
+    <axis xyz="0 1 0"/>
+    <limit effort="100" velocity="100.0"  lower="-5000" upper="5000" />
+  </joint>
+  
+  <joint type="revolute" name="right_wheel_hinge">
+    <origin xyz="0.0 -0.28 0.0" rpy="0.0 0.0 0.0"/>
+    <child link="right_wheel">right_wheel</child>
+    <parent link="base_link">base_link</parent>
+    <axis xyz="0 1 0"/>
+    <limit effort="100" velocity="100.0"  lower="-5000" upper="5000" />
+  </joint>
+  
+  <link name="left_wheel">
+    <collision name="collision">
+      <origin xyz="0.0 0.0 0.0" rpy="0.0 ${PI/2} ${PI/2}"/>
+      <geometry>
+        <cylinder length="0.047" radius="0.1015"/>
+      </geometry>
+    </collision>
+    
+    <visual name="visual">
+      <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+      <geometry>
+        <mesh filename="package://igvc/meshes/front_wheel.dae"/>
+      </geometry>
+    </visual>
+    
+    <inertial>
+       <mass value="3.4" />
+       <origin xyz="0.0 0.0 0.0" rpy="0.0 ${PI/2} ${PI/2}"/>
+       <xacro:cylinder_inertia m="3.4" r="0.1015" h="0.047"/>
+    </inertial>
+  </link>
+  
+  <link name="right_wheel">
+    <collision name="collision">
+      <origin xyz="0.0 0.0 0.0" rpy="0.0 ${PI/2} ${PI/2}"/>
+      <geometry>
+        <cylinder length="0.047" radius="0.1015"/>
+      </geometry>
+    </collision>
+    
+    <visual name="visual">
+      <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+      <geometry>
+        <mesh filename="package://igvc/meshes/front_wheel.dae"/>
+      </geometry>
+    </visual>
+    
+    <inertial>
+       <mass value="3.4" />
+       <origin xyz="0.0 0.0 0.0" rpy="0.0 ${PI/2} ${PI/2}"/>
+       <xacro:cylinder_inertia m="3.4" r="0.1015" h="0.047"/>
+    </inertial>
+  </link>
+</robot>

--- a/igvc/urdf/sensors/mid360.urdf.xacro
+++ b/igvc/urdf/sensors/mid360.urdf.xacro
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<robot name="sensor_velodyne" xmlns:xacro="http://ros.org/wiki/xacro"
+                              xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+                              xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
+
+  <xacro:property name="livox" value="0.1" /> <!-- Size of square 'hokuyo' box -->
+  <xacro:macro name="sensor_livox" params="name parent *origin min_angle max_angle samples">
+    <joint name="${name}_joint" type="fixed">
+      <xacro:insert_block name="origin"/>
+      <axis xyz="0 1 0"/>
+      <parent link="${parent}"/>
+      <child link="${name}_frame"/>
+    </joint>
+
+    <link name="${name}_frame">
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+            <box size="0.1 0.1 0.1"/>
+        </geometry>
+      </collision>
+
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://igvc/meshes/velodyne.dae"/>
+        </geometry>
+      </visual>
+
+      <inertial>
+        <mass value="0.0001"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+      </inertial>
+    </link>
+    
+    <gazebo reference="velodyne_link">
+      <sensor type="ray" name="head_velodyne_sensor">
+        <pose>0 0 0 0 0 0</pose>
+        <visualize>false</visualize>
+        <update_rate>10</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <resolution>1</resolution>
+              <samples>1875</samples>
+              <min_angle>${-PI}</min_angle>
+              <max_angle>${PI}</max_angle>
+            </horizontal>
+            <vertical>
+              <resolution>1</resolution>
+              <samples>16</samples>
+              <min_angle>${-PI/25}</min_angle>
+              <max_angle>${PI/3.5}</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>0.9</min>
+            <max>100</max>
+            <resolution>0.001</resolution>
+          </range>
+        </ray>
+        
+        <plugin name="gazebo_ros_laser_controller" filename="libgazebo_ros_velodyne_laser.so">
+          <topicName>/livox/points</topicName>
+          <frameName>livox_frame</frameName>
+          <min_range>0.9</min_range>
+          <max_range>100</max_range>
+          <gaussianNoise>0.01</gaussianNoise>
+        </plugin>
+      </sensor>
+    </gazebo>
+    
+    <!--
+    <gazebo reference="velodyne_link">
+    <sensor type="ray" name="head_velodyne_sensor">
+      <pose>0 0 0 0 0 0</pose>
+      <visualize>false</visualize>
+      <update_rate>40</update_rate>
+      <ray>
+        <scan>
+          <horizontal>
+            <resolution>1</resolution>
+            <samples>${samples}</samples>
+            <min_angle>${min_angle}</min_angle>
+            <max_angle>${max_angle}</max_angle>
+          </horizontal>
+        </scan>
+        <range>
+          <min>0.10</min>
+          <max>100.0</max>
+          <resolution>0.01</resolution>
+        </range>
+        <noise>
+          <type>gaussian</type>
+          <mean>0.0</mean>
+          <stddev>0.01</stddev>
+        </noise>
+      </ray>
+      <plugin name="gazebo_ros_head_hokuyo_controller" filename="libgazebo_ros_laser.so">
+        <topicName>/scan</topicName>
+        <frameName>velodyne_link</frameName>
+      </plugin>
+    </sensor>
+  </gazebo>
+  -->
+
+  </xacro:macro>
+
+</robot>


### PR DESCRIPTION
Mid-360で今までのナビゲーションが実行できるように、launchファイルの追加とURDFファイルの変更を行いました。
Mid-360のメッセージ型がカスタムメッセージなので、Pointcloud2に変換するノードを追加しました。
このノードは、livox_ros_driver2[https://github.com/Livox-SDK/livox_ros_driver2](https://github.com/Livox-SDK/livox_ros_driver2)のインストールが必要なので、インストールしていないとビルド時にエラーが起こります。

launchファイルは、`sensors.launch` →  `mid360_sensors.launch`
                                 `segmentation.launch` →  `mid360_segmentation.launch`
とすることで、velodyneからmid-360に切り替えられます。

URDFファイルは、Velodyneのvertical_angleを変更することで、疑似的にmid-360を再現しています。
